### PR TITLE
Moving unit test script execution to after build

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -9,9 +9,9 @@ phases:
       - echo "nothing to do in install"
   pre_build:
     commands:
-      - echo "Installing dependencies and executing unit tests - `pwd`"
-      - cd deployment && chmod +x ./run-unit-tests.sh && ./run-unit-tests.sh
-      - echo "Installing dependencies and executing unit tests completed `date`"
+      # - echo "Installing dependencies and executing unit tests - `pwd`"
+      # - cd deployment && chmod +x ./run-unit-tests.sh && ./run-unit-tests.sh
+      - echo "Skipping pre-build unit tests and running after build `date`"
   build:
     commands:
       - echo "Starting build `date` in `pwd`"
@@ -20,6 +20,10 @@ phases:
       - echo "Starting open-source-dist `date` in `pwd`"
       - chmod +x ./build-open-source-dist.sh && ./build-open-source-dist.sh $SOLUTION_NAME
       - echo "Open Source Dist completed `date`"
+      # Run unit tests after building
+      - echo "Installing dependencies and executing unit tests - `pwd`"
+      - cd deployment && pip install ./pkg/aws_virtual_waiting_room_common-1.0.0-py3-none-any.whl && chmod +x ./run-unit-tests.sh && ./run-unit-tests.sh
+      - echo "Installing dependencies and executing unit tests completed `date`"
   post_build:
     commands:
       - echo "Retrieving next stage buildspec `date` in `pwd`"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Need to hold-off unit tests on Solution Builder's pipeline until build completes and we have units to test.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
