### PR TITLE
Bugfix: Lock bleach to a supported version

### DIFF
--- a/source/shared/aws-virtual-waiting-room-common/setup.py
+++ b/source/shared/aws-virtual-waiting-room-common/setup.py
@@ -28,5 +28,5 @@ setuptools.setup(
     packages=setuptools.find_packages(where="."),
     python_requires=">=3.8",
     install_requires=[
-        'bleach',
+        'bleach~=4.1.0',
     ])


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Building and deploying the solution from source succeeds, however, request-handling lambdas fail when sanitizing user inputs.
It looks like there was no version constraint on bleach, and they've since released version 5 which has some breaking changes.
See: https://bleach.readthedocs.io/en/latest/changes.html#version-5-0-0-april-7th-2022

This locks the version constraint to a known, working version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
